### PR TITLE
Added a default value

### DIFF
--- a/bullet/utils.py
+++ b/bullet/utils.py
@@ -5,7 +5,11 @@ import string
 from .charDef import *
 from . import colors
 
-_, n = os.popen('stty size', 'r').read().split()
+try:
+    _, n = os.popen('stty size', 'r').read().split()
+except ValueError:
+    # Default values
+    _, n = (80, 25)
 COLUMNS = int(n)  ## Size of console
 
 def mygetc():


### PR DESCRIPTION
When bullet calculate the width of terminal could fail throwing this stacktrace:

```  File ".../bullet/utils.py", line 8, in <module>
    _, n = os.popen('stty size', 'r').read().split()
ValueError: not enough values to unpack (expected 2, got 0)```

Using it we asume the standard console width when it fails